### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -50,6 +50,8 @@ class ITK_TEMPLATE_EXPORT AdaptiveNonLocalMeansDenoisingImageFilter final :
   public NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(AdaptiveNonLocalMeansDenoisingImageFilter);
+
   /** Standard class typedefs. */
   typedef AdaptiveNonLocalMeansDenoisingImageFilter                 Self;
   typedef NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>  Superclass;
@@ -173,9 +175,6 @@ protected:
   void AfterThreadedGenerateData() override;
 
 private:
-
-  AdaptiveNonLocalMeansDenoisingImageFilter( const Self& ) = delete;
-  void operator=( const Self& ) = delete;
 
   RealType CalculateCorrectionFactor( RealType );
 

--- a/include/itkNonLocalPatchBasedImageFilter.h
+++ b/include/itkNonLocalPatchBasedImageFilter.h
@@ -36,6 +36,8 @@ class ITK_TEMPLATE_EXPORT NonLocalPatchBasedImageFilter :
   public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(NonLocalPatchBasedImageFilter);
+
   /** Standard class typedefs. */
   using Self = NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
@@ -169,13 +171,6 @@ protected:
   NeighborhoodOffsetListType                           m_NeighborhoodPatchOffsetList;
 
   RegionType                                           m_TargetImageRegion;
-
-
-private:
-
-  NonLocalPatchBasedImageFilter( const Self& ) = delete;
-  void operator=( const Self& ) = delete;
-
 };
 
 } // end namespace itk

--- a/include/itkVarianceImageFilter.h
+++ b/include/itkVarianceImageFilter.h
@@ -39,6 +39,8 @@ class ITK_TEMPLATE_EXPORT VarianceImageFilter final :
   public BoxImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VarianceImageFilter);
+
   /** Extract dimension from input and output image. */
   itkStaticConstMacro(InputImageDimension, unsigned int,
                       TInputImage::ImageDimension);
@@ -94,10 +96,6 @@ protected:
    *     BoxImageFilter::GenerateData() */
   void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
                             ThreadIdType threadId) override;
-
-private:
-  VarianceImageFilter(const Self &) = delete;
-  void operator=(const Self &) = delete;
 };
 } // end namespace itk
 


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the toolkit when disallowing the copy constructor and the assign operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to the `public` section
following the discussion in
https://discourse.itk.org/t/itk-disallow-copy-and-assign/648