### PR TITLE
COMP: Update to new ITK_DISALLOW_COPY_AND_MOVE macro

### DIFF
--- a/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -50,7 +50,7 @@ class ITK_TEMPLATE_EXPORT AdaptiveNonLocalMeansDenoisingImageFilter final :
   public NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(AdaptiveNonLocalMeansDenoisingImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(AdaptiveNonLocalMeansDenoisingImageFilter);
 
   /** Standard class typedefs. */
   typedef AdaptiveNonLocalMeansDenoisingImageFilter                 Self;

--- a/include/itkNonLocalPatchBasedImageFilter.h
+++ b/include/itkNonLocalPatchBasedImageFilter.h
@@ -62,7 +62,7 @@ class ITK_TEMPLATE_EXPORT NonLocalPatchBasedImageFilter :
   public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(NonLocalPatchBasedImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(NonLocalPatchBasedImageFilter);
 
   /** Standard class typedefs. */
   using Self = NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>;

--- a/include/itkVarianceImageFilter.h
+++ b/include/itkVarianceImageFilter.h
@@ -39,7 +39,7 @@ class ITK_TEMPLATE_EXPORT VarianceImageFilter final :
   public BoxImageFilter< TInputImage, TOutputImage >
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VarianceImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VarianceImageFilter);
 
   /** Extract dimension from input and output image. */
   itkStaticConstMacro(InputImageDimension, unsigned int,

--- a/test/itkAdaptiveNonLocalMeansDenoisingImageFilterTest.cxx
+++ b/test/itkAdaptiveNonLocalMeansDenoisingImageFilterTest.cxx
@@ -147,7 +147,7 @@ int itkAdaptiveNonLocalMeansDenoisingImageFilterTest( int argc, char * argv[] )
 
   auto similarityMetric = static_cast<DenoiserType::SimilarityMetricEnum>(std::atoi(argv[3]));
   filter->SetSimilarityMetric(similarityMetric);
-  ITK_TEST_SET_GET_VALUE(similarityMetric, filter->GetSimilarityMetric())
+  ITK_TEST_SET_GET_VALUE(similarityMetric, filter->GetSimilarityMetric());
 
   using CommandType = CommandProgressUpdate<DenoiserType>;
   CommandType::Pointer observer = CommandType::New();


### PR DESCRIPTION
Replace the deprecated ITK_DISALLOW_COPY_AND_ASSIGN with
new better descriptive name ITK_DISALLOW_COPY_AND_MOVE.