### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
+++ b/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkAdaptiveNonLocalMeansDenoisingImageFilter_hxx
 #define itkAdaptiveNonLocalMeansDenoisingImageFilter_hxx
 
-#include "itkAdaptiveNonLocalMeansDenoisingImageFilter.h"
 
 #include "itkArray.h"
 #include "itkDiscreteGaussianImageFilter.h"

--- a/include/itkNonLocalPatchBasedImageFilter.hxx
+++ b/include/itkNonLocalPatchBasedImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkNonLocalPatchBasedImageFilter_hxx
 #define itkNonLocalPatchBasedImageFilter_hxx
 
-#include "itkNonLocalPatchBasedImageFilter.h"
 
 #include "itkNeighborhood.h"
 

--- a/include/itkVarianceImageFilter.hxx
+++ b/include/itkVarianceImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkVarianceImageFilter_hxx
 #define itkVarianceImageFilter_hxx
-#include "itkVarianceImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkNeighborhoodInnerProduct.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

