### PR TITLE
COMP: Use modern macro for name of class

### DIFF
--- a/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -66,7 +66,7 @@ public:
   itkNewMacro(Self);
 
   /** ImageDimension constants */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Some convenient typedefs. */
   typedef TInputImage                        InputImageType;

--- a/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -60,7 +60,7 @@ public:
   typedef SmartPointer<const Self>                                 ConstPointer;
 
   /** Runtime information support. */
-  itkTypeMacro(AdaptiveNonLocalMeansDenoisingImageFilter, NonLocalPatchBasedImageFilter);
+  itkOverrideGetNameOfClassMacro(AdaptiveNonLocalMeansDenoisingImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/include/itkNonLocalPatchBasedImageFilter.h
+++ b/include/itkNonLocalPatchBasedImageFilter.h
@@ -71,7 +71,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Runtime information support. */
-  itkTypeMacro(NonLocalPatchBasedImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(NonLocalPatchBasedImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/include/itkNonLocalPatchBasedImageFilter.h
+++ b/include/itkNonLocalPatchBasedImageFilter.h
@@ -77,7 +77,7 @@ public:
   itkNewMacro(Self);
 
   /** ImageDimension constants */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Some convenient typedefs. */
   using InputImageType = TInputImage;

--- a/include/itkVarianceImageFilter.h
+++ b/include/itkVarianceImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VarianceImageFilter, BoxImageFilter);
+  itkOverrideGetNameOfClassMacro(VarianceImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::PixelType               InputPixelType;

--- a/include/itkVarianceImageFilter.h
+++ b/include/itkVarianceImageFilter.h
@@ -41,8 +41,8 @@ public:
   ITK_DISALLOW_COPY_AND_MOVE(VarianceImageFilter);
 
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Convenient typedefs for simplifying declarations. */
   typedef TInputImage  InputImageType;


### PR DESCRIPTION
When preparing for the future with ITK by setting
ITK_FUTURE_LEGACY_REMOVE:BOOL=ON
ITK_LEGACY_REMOVEBOOL=ON

The future preferred macro should be used
│ -  itkTypeMacro
│ +  itkOverrideGetNameOfClassMacro