### PR TITLE
ENH: Use latest actions, do not pin to latest version

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master


### PR DESCRIPTION
The convention of only specifying the MAJOR version
is the indicator that the latest version in that
series should be used.

By not specifying the MINOR and PATCH, the exact versions
is not pinned, but the latest in that series is chosen.
(i.e. the v5 tag is updated every time a new MINOR or PATCH
tag is generated).

This allows benefiting from minor patch fixes without needing
to update workflows.
